### PR TITLE
Standardize spelling of 'Résumé' to 'Resume' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Blazor WebAssembly resume site I built to present my experience, practice modern .NET UI patterns, and experiment with deployment and hosting workflows. The project focuses on polishing my existing C#/.NET web skills while picking up new ones around Blazor, repo hygiene, Azure-hosted assets, and Cloudflare.
 
-## Live Site & Résumé
+## Live Site & Resume
 - Live: https://bryce.campain.me
 - Repo: https://github.com/bcampain/brycecampain-resume
 - PDF: `wwwroot/Bryce-Campain-Resume-Nov2025.pdf` (linked in the app)
@@ -14,7 +14,7 @@ A Blazor WebAssembly resume site I built to present my experience, practice mode
 
 ## Features
 - Resume presented as an interactive single-page Blazor app
-- Downloadable résumé PDF
+- Downloadable resume PDF
 - “Fun” mode with animated cards; animation timings fetched from signed blob storage with local `wwwroot/config.json` fallback
 - SEO-friendly meta tags, Open Graph, canonical URL
 - Responsive layout with dark gradient styling
@@ -31,7 +31,7 @@ dotnet watch run
 ## Configuration
 - Animation config: fetched from a signed Azure Blob URL first, falling back to `wwwroot/config.json`. You can use that config as a template and save to blob storage.
 - SEO/meta: adjust title, description, Open Graph, and canonical link in `wwwroot/index.html`.
-- Résumé PDF: replace `wwwroot/Bryce-Campain-Resume-Nov2025.pdf` and keep the link in `Pages/Home.razor` in sync.
+- Resume PDF: replace `wwwroot/Bryce-Campain-Resume-Nov2025.pdf` and keep the link in `Pages/Home.razor` in sync.
 
 ## Deployment
 - Build/publish: `dotnet publish -c Release`
@@ -45,7 +45,7 @@ dotnet watch run
 
 ## Roadmap
 - Expand Fun Mode interactions and animation polish
-- Track résumé downloads via analytics
+- Track resume downloads via analytics
 - Add a career timeline component
 - **Long Term:**
   - Generalize the app into a reusable resume template (remove personal-only references and make customization straightforward)


### PR DESCRIPTION
- Replaced all instances of é with e.